### PR TITLE
fix: types not found, package.json update

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,9 +49,9 @@
       "react"
     ]
   },
-  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
       "import": "./dist/index.mjs"
     }


### PR DESCRIPTION
Refer to this: https://stackoverflow.com/questions/76211877/the-xxxx-library-may-need-to-update-its-package-json-or-typings-ts

Import error: There are types at `node_modules/chakra-ui-simple-autocomplete/dist/index.d.ts`, but this result could not be resolved when respecting package.json "exports". The chakra-ui-simple-autocomplete library may need to update its package.json or typings. 
```json
"dependencies": {
    "@chakra-ui/react": "^2.7.1",
    "@emotion/react": "^11.11.1",
    "@emotion/styled": "^11.11.0",
    "@supabase/supabase-js": "^2.26.0",
    "@types/react-slick": "^0.23.10",
    "chakra-ui-simple-autocomplete": "^2.3.0",
    "dayjs": "^1.11.8",
    "framer-motion": "^10.12.17",
    "react": "^18.2.0",
    "react-dom": "^18.2.0",
    "react-hook-form": "^7.45.1",
    "react-icons": "^4.10.1",
    "react-intersection-observer": "^9.5.2",
    "react-query": "^3.39.3",
    "react-router-dom": "^6.14.0",
    "react-slick": "^0.29.0",
    "vite-tsconfig-paths": "^4.2.0",
    "yup": "^1.2.0"
  }
```